### PR TITLE
added single function that works for file or object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,47 +21,63 @@ from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
 plot = plot_slice_of_dagmc_geometry(
     dagmc_file_or_trimesh_object='dagmc.h5m',
-    plane_normal = [0, 0, 1],
+    plane_normal=[0, 0, 1],
 )
 
 plot.show()
 ```
+![dagmc slice plot](https://user-images.githubusercontent.com/8583900/138321345-9187aa57-c3bc-4940-ae28-1237df394eba.png)
 
 Create a plot of a slice through the geometry perpendicular to the Z axis,
-offset by 20cm and with default settings elsewhere.
+offset by 200cm and with default settings elsewhere.
 ```python
 from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
 plot = plot_slice_of_dagmc_geometry(
     dagmc_file_or_trimesh_object='dagmc.h5m',
-    plane_origin= [0, 0, 20],
-    plane_normal = [0, 0, 1],
+    plane_origin=[0, 0, 200],
+    plane_normal=[0, 0, 1],
 )
 
 plot.show()
 ```
+![dagmc slice plot](https://user-images.githubusercontent.com/8583900/138321353-707bf553-1255-4a87-a3b9-d97aa3ecb67b.png)
 
 Create a plot of a slice through the geometry perpendicular to the Y axis, with
-a rotation of 90 degrees and with default settings elsewhere.
+a rotation of 45 degrees and with default settings elsewhere. Also saves the
+plot with a high resolution (DPI)
 ```python
 from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
 plot = plot_slice_of_dagmc_geometry(
     dagmc_file_or_trimesh_object='dagmc.h5m',
-    plane_normal = [0, 1, 0],
-    rotate_plot=270
+    plane_normal=[0, 1, 0],
+    rotate_plot=45,
 )
 
-plot.show()
+plot.savefig('my_plot3.png', dpi=600)
 ```
+![dagmc slice plot](https://user-images.githubusercontent.com/8583900/138321358-194162d4-8d42-4090-811e-0dd3768a328d.png)
 
-Saves a png image of a plot of a slice through the geometry perpendicular to the X axis and with default settings elsewhere.
+Saves a png image of a plot of a slice through the geometry perpendicular to
+the X axis and with default settings elsewhere.
 ```python
 from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
-plot = plot_slice_of_dagmc_geometry(
+plot_slice_of_dagmc_geometry(
     dagmc_file_or_trimesh_object='dagmc.h5m',
     plane_normal = [1, 0, 0],
-    output_filename='my_plot.png'
+    rotate_plot=270,
+    output_filename='my_plot4.png'
 )
 ```
+![dagmc slice plot](https://user-images.githubusercontent.com/8583900/138321363-0e7604b3-74eb-44e8-8aa2-9586c008b40d.png)
+
+
+# Related packages
+
+This package is used by the [regular_mesh_plotter](https://github.com/fusion-energy/regular_mesh_plotter) Python package to combine slice plots with regular mesh tally results and produce images like below.
+
+![paramak plot openmc regular mesh tally](https://user-images.githubusercontent.com/8583900/138322007-daf1eb6f-ca42-4d9c-9581-8dbc9da94fe5.png)
+
+![paramak plot openmc regular mesh tally](https://user-images.githubusercontent.com/8583900/138322010-c7ca7ced-1a37-4af5-b7a4-7d5853a2b9bb.png)

--- a/README.md
+++ b/README.md
@@ -9,44 +9,47 @@ pip install dagmc_geometry_slice_plotter
 
 # Python API Usage
 
-These examples assume you have a h5m file called ```dagmc.h5m``` in the same folder that the Python script is being run from.
+These examples assume you have a h5m file called ```dagmc.h5m``` in the same
+folder that the Python script is being run from.
 
-Create a plot of a slice through the geometry perpendicular to the Z axis and 
+Create a plot of a slice through the geometry perpendicular to the Z axis and
 default settings elsewhere. This will slice through the the center of the
 geometry as plane_origin has not been specified.
 
 ```python
-from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_file
+from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
-plot = plot_slice_of_dagmc_file(
-    dagmc_filename='dagmc.h5m',
+plot = plot_slice_of_dagmc_geometry(
+    dagmc_file_or_trimesh_object='dagmc.h5m',
     plane_normal = [0, 0, 1],
 )
 
 plot.show()
 ```
 
-Create a plot of a slice through the geometry perpendicular to the Z axis, offset by 20cm and with default settings elsewhere.
+Create a plot of a slice through the geometry perpendicular to the Z axis,
+offset by 20cm and with default settings elsewhere.
 ```python
-from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_file
+from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
-plot = plot_slice_of_dagmc_file(
-    dagmc_filename='dagmc.h5m',
-    plane_origin= 20,
+plot = plot_slice_of_dagmc_geometry(
+    dagmc_file_or_trimesh_object='dagmc.h5m',
+    plane_origin= [0, 0, 20],
     plane_normal = [0, 0, 1],
 )
 
 plot.show()
 ```
 
-Create a plot of a slice through the geometry perpendicular to the Y axis, with a rotation of 90 degrees and with default settings elsewhere.
+Create a plot of a slice through the geometry perpendicular to the Y axis, with
+a rotation of 90 degrees and with default settings elsewhere.
 ```python
-from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_file
+from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
-plot = plot_slice_of_dagmc_file(
-    dagmc_filename='dagmc.h5m',
+plot = plot_slice_of_dagmc_geometry(
+    dagmc_file_or_trimesh_object='dagmc.h5m',
     plane_normal = [0, 1, 0],
-    rotate_plot=90
+    rotate_plot=270
 )
 
 plot.show()
@@ -54,10 +57,10 @@ plot.show()
 
 Saves a png image of a plot of a slice through the geometry perpendicular to the X axis and with default settings elsewhere.
 ```python
-from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_file
+from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_geometry
 
-plot = plot_slice_of_dagmc_file(
-    dagmc_filename='dagmc.h5m',
+plot = plot_slice_of_dagmc_geometry(
+    dagmc_file_or_trimesh_object='dagmc.h5m',
     plane_normal = [1, 0, 0],
     output_filename='my_plot.png'
 )

--- a/dagmc_geometry_slice_plotter/__init__.py
+++ b/dagmc_geometry_slice_plotter/__init__.py
@@ -1,3 +1,4 @@
 
 from .utils import plot_slice_of_dagmc_file
 from .utils import plot_slice_of_trimesh_object
+from .utils import plot_slice_of_dagmc_geometry

--- a/dagmc_geometry_slice_plotter/utils.py
+++ b/dagmc_geometry_slice_plotter/utils.py
@@ -1,9 +1,61 @@
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import matplotlib.pyplot as plt
 import trimesh
 from matplotlib import transforms
+
+
+def plot_slice_of_dagmc_geometry(
+    dagmc_file_or_trimesh_object, 
+    plane_origin: Tuple[float, float, float] = None,
+    plane_normal: Tuple[float, float, float] = [0, 0, 1],
+    rotate_plot: float = 0,
+    output_filename: Optional[str] = None,
+):
+    """Slices through a 3D DAGMC geometry file (h5m format) and produces a
+    matplotlib plot of the slice.
+
+    Args:
+        dagmc_file_or_trimesh_object: the filename of the DAGMC h5m file or a
+            A trimesh mesh object. This can be created from a DAGMC h5m file in
+            the following way 'trimesh_mesh_object = trimesh.load_mesh(
+            dagmc_filename, process=False)'.
+        plane_origin: the origin of the plain, if None then the centroid of
+            the mesh will be used.
+        plane_normal: the plane to slice the geometry on. Defaults to slicing
+            along the Z plane which is input as [0, 0, 1].
+        rotate_plot: the angle in degrees to rotate the plot by. Useful when
+            used in conjunction with changing plane_normal to orientate the
+            plot correctly.
+        output_filename: if specified then a the plot will be saved as an image
+            with default settings. Alternatively the returned plot object can
+            be saved using that matplotlib .savefig() method.
+
+    Return:
+        A matplotlib.pyplot object
+    """
+
+    if isinstance(dagmc_file_or_trimesh_object, str):
+        slice = plot_slice_of_dagmc_file(
+            dagmc_filename=dagmc_file_or_trimesh_object,
+            plane_origin=plane_origin,
+            plane_normal=plane_normal,
+            rotate_plot=rotate_plot,
+            output_filename=output_filename
+        )
+
+    else:
+
+        slice = plot_slice_of_trimesh_object(
+            trimesh_mesh_object=dagmc_file_or_trimesh_object,
+            plane_origin=plane_origin,
+            plane_normal=plane_normal,
+            rotate_plot=rotate_plot,
+            output_filename=output_filename
+        )
+
+    return slice
 
 
 def plot_slice_of_dagmc_file(
@@ -62,7 +114,7 @@ def plot_slice_of_trimesh_object(
 
     Args:
         trimesh_mesh_object: A trimesh mesh object. This can be created from a
-            a DAGMC h5m file in the following way 'trimesh_mesh_object =
+            DAGMC h5m file in the following way 'trimesh_mesh_object =
             trimesh.load_mesh(dagmc_filename, process=False)'
         plane_origin: the origin of the plain, if None then the centroid of
             the mesh will be used.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "trimesh",
         "shapely",
         "scipy",
-        "meshio"  # required to allow trimesh to read h5m files
+        "meshio",  # required to allow trimesh to read h5m files
+        "h5py"
     ],
 )

--- a/tests/test_plot_slice_of_dagmc_file.py
+++ b/tests/test_plot_slice_of_dagmc_file.py
@@ -23,7 +23,6 @@ class TestPlotSliceOfDagmcFile(unittest.TestCase):
 
         self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
         self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_bigger = "dagmc.h5m"
 
     def test_create_default_plot(self):
         """Tests returned object is a matplotlib plot"""

--- a/tests/test_plot_slice_of_trimesh_object.py
+++ b/tests/test_plot_slice_of_trimesh_object.py
@@ -3,12 +3,13 @@ import tarfile
 import unittest
 import urllib.request
 from pathlib import Path
+import trimesh
 
 import matplotlib.pyplot as plt
-from dagmc_geometry_slice_plotter import plot_slice_of_dagmc_file
+from dagmc_geometry_slice_plotter import plot_slice_of_trimesh_object
 
 
-class TestPlotSliceOfDagmcFile(unittest.TestCase):
+class TestPlotSliceOfTrimeshObject(unittest.TestCase):
     """Tests the neutronics utilities functionality and use cases"""
 
     def setUp(self):
@@ -21,21 +22,23 @@ class TestPlotSliceOfDagmcFile(unittest.TestCase):
             tar.extractall("tests")
             tar.close()
 
-        self.h5m_filename_smaller = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
-        self.h5m_filename_bigger = "dagmc.h5m"
+        h5m_filename_smaller = "tests/neutronics_workflow-0.0.2/example_01_single_volume_cell_tally/stage_2_output/dagmc.h5m"
+        h5m_filename_bigger = "tests/neutronics_workflow-0.0.2/example_02_multi_volume_cell_tally/stage_2_output/dagmc.h5m"
+
+        self.trimesh_mesh_object_smaller = trimesh.load_mesh(h5m_filename_smaller, process=False)
+        self.trimesh_mesh_object_bigger = trimesh.load_mesh(h5m_filename_bigger, process=False)
 
     def test_create_default_plot(self):
         """Tests returned object is a matplotlib plot"""
 
-        plot = plot_slice_of_dagmc_file(
-            dagmc_filename=self.h5m_filename_smaller,
+        plot = plot_slice_of_trimesh_object(
+            trimesh_mesh_object=self.trimesh_mesh_object_smaller,
         )
 
         assert isinstance(plot, type(plt))
 
-        plot2 = plot_slice_of_dagmc_file(
-            dagmc_filename=self.h5m_filename_bigger,
+        plot2 = plot_slice_of_trimesh_object(
+            trimesh_mesh_object=self.trimesh_mesh_object_bigger,
         )
 
         assert isinstance(plot2, type(plt))
@@ -45,8 +48,8 @@ class TestPlotSliceOfDagmcFile(unittest.TestCase):
 
         os.system("rm test_plot.png")
 
-        plot_slice_of_dagmc_file(
-            dagmc_filename=self.h5m_filename_smaller,
+        plot_slice_of_trimesh_object(
+            trimesh_mesh_object=self.trimesh_mesh_object_smaller,
             output_filename="test_plot.png",
         )
 
@@ -54,8 +57,8 @@ class TestPlotSliceOfDagmcFile(unittest.TestCase):
 
         os.system("rm test_plot2.png")
 
-        plot_slice_of_dagmc_file(
-            dagmc_filename=self.h5m_filename_bigger,
+        plot_slice_of_trimesh_object(
+            trimesh_mesh_object=self.trimesh_mesh_object_bigger,
             output_filename="test_plot2.png",
         )
 


### PR DESCRIPTION
Adds a function called ```plot_slice_of_dagmc_geometry``` that can accept either a dagmc file name or a trimesh object and then produce a plot.

This provides a single entry function for users